### PR TITLE
Add flake.nix to project

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+
+#### NOTE: This flake is provided only as a convenience for Nix users.
+# The SDK versions may drift out of sync with the project dependencies.
+# If you are a Nix user and find that the versions don't match,
+# please update the flake and make a PR.
+
+description = "Flutter 3.24.x";
+inputs = {
+  nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable"; # Flutter 3.24 is 'flutter' on the unstable channel as of 24.05
+  flake-utils.url = "github:numtide/flake-utils";
+};
+outputs = { self, nixpkgs, flake-utils }:
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+        config = {
+          android_sdk.accept_license = true;
+          allowUnfree = true;
+        };
+      };
+      buildToolsVersion = "34.0.0";
+      androidComposition = pkgs.androidenv.composeAndroidPackages {
+        buildToolsVersions = [ buildToolsVersion "30.0.3" ];
+        platformVersions = [ "34" "33" "31"];
+        abiVersions = [ "armeabi-v7a" "arm64-v8a" ];
+      };
+      androidSdk = androidComposition.androidsdk;
+    in
+    {
+      devShell =
+        with pkgs; mkShell rec {
+          ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
+          buildInputs = [
+            flutter
+            androidSdk # The customized SDK that we've made above
+            jdk17
+            aapt
+          ];
+        };
+    });
+}


### PR DESCRIPTION
Added a 'flake.nix' file that creates a dev shell that can build the project with `flutter build apk`. 

The flake.lock dependencies match commit 8983dc1. This flake can build release v1.0.3.

# Usage

To use the flake: [Install Nix](https://nixos.org/download/) and then [enable flake support](https://nixos.wiki/wiki/Flakes/). Because the flake uses unfree packages, you will also need to [allow unfree software](https://nixos.wiki/wiki/Unfree_Software). The easiest way is to temporarily `export NIXPKGS_ALLOW_UNFREE=1` before running.

To launch the dev shell, run `nix develop`. Nix will download all required dependencies and build a temporary shell where all are available, without polluting or conflicting with the rest of the system. Once inside the shell, run `flutter build apk` or any command you need.

# Changing SDK versions

To update or modify SDK versions, you can change the versions strings in line 23 and 25, and the array of platform versions at line 26. The flake will build a custom SDK package with those versions available. If another dependency is needed inside the shell, you can add the [package name](https://search.nixos.org/packages) to the `buildInputs` array.

# Updatting flutter

For updating the flutter version, it may be necessary to change a flake input (for example, to point nixpkgs.url to the next stable release). Depending on the channel, the package name for the buildInputs may be either  `flutter` or a versioned package like  `flutter326`. You can [search](https://search.nixos.org/packages) the package names available for each channel. 

When changing the flake inputs, it is necessary to run  `nix flake update` in order to build a new  `flake.lock` with the updated inputs. 